### PR TITLE
Turn off Travis notification to Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,3 @@ deploy:
   local_dir: dist
   on:
     branch: master
-notifications:
-  webhooks:
-    urls:
-      - https://fs-bitbot.herokuapp.com/travis


### PR DESCRIPTION
The Travis notifications to Slack intercepted by bitbot need refactoring, since they're showing the latest commit from this repo instead of `ui-eholdings`. This turns them off until we can revisit bitbot.