### PR TITLE
Use stripes-cli syntax to run tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
   yarn: true
 script:
   - yarn lint
-  - yarn test --single-run --browsers=$BROWSER
+  - yarn test --karma.singleRun --karma.browsers=$BROWSER
 before_deploy:
   - NODE_ENV=production yarn build
 deploy:


### PR DESCRIPTION
## Purpose
With Stripes CLI now used by `ui-eholdings`, running the tests in `folio-ui-eholdings-deploy` is broken.

## Approach
Use the strategy figured out for passing options to karma in https://github.com/folio-org/ui-eholdings/pull/174.