### PR TITLE
Don't run eholdings test suite on deploy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ install:
 cache:
   yarn: true
 script:
-  - yarn lint
-  - yarn test --karma.singleRun --karma.browsers=$BROWSER
+  - echo "Test for the Deployment itself should go here."
 before_deploy:
   - NODE_ENV=production yarn build
 deploy:


### PR DESCRIPTION
## Purpose

Whenever this build is run, we lint the eholdings source, and then run the eholdings suite tests before deploying. This takes several minutes as can be seen here:

https://travis-ci.org/folio-org/ui-eholdings/jobs/330103495

But this linting and testing work isn't necessary however because the test suite is being run as part of the actual repo build. In fact, because master is protected by the test suite on the eholding repository, it's impossible for any changes to actually be seen by this deployment repo unless they've already run (and passed) the test suite.

## Approach

This removes those checks as entirely redundant so that we can have faster merge-to-deployment times.