### PR TITLE
Deploy to S3 with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.9
+    working_directory: ~/ui-eholdings
+    steps:
+      - run:
+          name: Check Out Repository
+          command: |
+            cd ~/
+            git clone --branch=master https://github.com/folio-org/ui-eholdings.git
+      - run:
+          name: Install Dependencies
+          command: yarn install
+      - run:
+          name: Build Bundle
+          command: NODE_ENV=production yarn build
+      - persist_to_workspace:
+          root: ~/ui-eholdings
+          paths:
+            - dist
+  deploy:
+    docker:
+      - image: cibuilds/aws
+    working_directory: ~/ui-eholdings
+    steps:
+      - attach_workspace:
+          at: ~/ui-eholdings
+      - run:
+          name: Deploy to S3
+          command: aws s3 sync dist s3://folio.frontside.io/ --delete --acl public-read --cache-control max-age=30
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           at: ~/ui-eholdings
       - run:
           name: Deploy to S3
-          command: aws s3 sync dist s3://folio.frontside.io/ --delete --acl public-read --cache-control max-age=30
+          command: aws s3 sync dist s3://folio.frontside.io/ --acl public-read --cache-control max-age=30
 
 workflows:
   version: 2


### PR DESCRIPTION
## Purpose
Our Travis/Superfeedr pipeline hasn't seemed to be working the last few days, so I'm expediting the move from Travis to CircleCI for deploying `ui-eholdings` and `mod-kb-ebsco`.
https://issues.folio.org/browse/UIEH-113

## Learning
Working with AWS in the CircleCI-provided docker images is a little clumsy (involves installing the Python-powered AWS CLI), but this image provided a clever workaround that could be implemented with CircleCI workflows: https://github.com/circleci/circleci-images/issues/53#issuecomment-354909236

`persist_to_workspace` persists the `dist` directory from the `circleci/node:8.9` box running the `build` job to the `cibuilds/aws` that can `attach_workspace` and run the `deploy` job.

## Open Questions
- [x] Is `--delete` the right behavior for uploading to S3? That will remove everything currently in the bucket. I don't think that's what the current Travis setup is doing.

## Next Steps
1. Set up Superfeedr to send to the CircleCI API
2. Remove `.travis.yml`
3. Set up this same pipeline for `mod-kb-ebsco` (quite a bit more involved)