### PR TITLE
Install AWS CLI in build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,11 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.9
+      - image: circleci/node:latest
     working_directory: ~/ui-eholdings
+    branches:
+      only:
+        - master
     steps:
       - run:
           name: Check Out Repository
@@ -16,29 +19,12 @@ jobs:
       - run:
           name: Build Bundle
           command: NODE_ENV=production yarn build
-      - persist_to_workspace:
-          root: ~/ui-eholdings
-          paths:
-            - dist
-  deploy:
-    docker:
-      - image: cibuilds/aws
-    working_directory: ~/ui-eholdings
-    steps:
-      - attach_workspace:
-          at: ~/ui-eholdings
+      - run:
+          name: Install AWS CLI
+          command: |
+            sudo apt-get update && sudo apt-get install -qq -y python-pip libpython-dev
+            curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
+            sudo pip install -q awscli --upgrade
       - run:
           name: Deploy to S3
           command: aws s3 sync dist s3://folio.frontside.io/ --acl public-read --cache-control max-age=30
-
-workflows:
-  version: 2
-  build-deploy:
-    jobs:
-      - build
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master


### PR DESCRIPTION
## Purpose
The Circle CI API doesn't support workflows yet, so we can only trigger a build through the API that has a single job.

## Approach
We need to install the AWS CLI on every build, instead of using a workflow that uses a pre-built container with AWS CLI installed.
