### PR TITLE
Use stripes framework 1.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-@folio:registry=https://repository.folio.org/repository/npm-folioci/
+@folio:registry=https://repository.folio.org/repository/npm-folio/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   },
   "dependencies": {
     "@folio/eholdings": "git+https://git@github.com/folio-org/ui-eholdings.git#master",
-    "@folio/stripes-cli": "^1.2.0"
+    "@folio/stripes": "^1.0.0",
+    "@folio/stripes-cli": "^1.2.0",
+    "react": "^16.5.2",
+    "react-dom": "^16.5.2",
+    "react-redux": "^5.0.7",
+    "redux": "^3.0.0",
+    "rxjs": "^5.0.0"
   }
 }


### PR DESCRIPTION
Follow-up to https://github.com/folio-org/ui-eholdings/pull/585

Also sets `folio.frontside.io` to only use explicitly released versions of `stripes-*` repos published to the `npm-folio` registry. `ui-eholdings` will continue to come from GitHub.